### PR TITLE
Fix: missing ScriptRunContext for new threads

### DIFF
--- a/src/lib/machine_learning/visuals.py
+++ b/src/lib/machine_learning/visuals.py
@@ -1,7 +1,7 @@
 from itertools import zip_longest
 import sys
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Tuple, Union
+from typing import Any, Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 from pathlib import Path
 import numpy as np
 import cv2
@@ -146,9 +146,9 @@ class PrettyMetricPrinter:
 
     def __post_init__(self):
         # more loss names to check for inverse delta_color
-        self._extra_lossnames: List[str] = [
+        self._extra_lossnames: Set[str] = {
             'categorical_crossentropy', 'iou_seg',
-            'val_categorical_crossentropy', 'val_iou_seg']
+            'val_categorical_crossentropy', 'val_iou_seg'}
         self._first: bool = True
 
     def write(self, metrics: Dict[str, float]):
@@ -161,7 +161,7 @@ class PrettyMetricPrinter:
             if not self.delta_color:
                 self.delta_color = {}
                 for name in metrics:
-                    if 'loss' in name or name in self._extra_lossnames:
+                    if 'loss' in name.lower() or name in self._extra_lossnames:
                         self.delta_color[name] = 'inverse'
                     else:
                         self.delta_color[name] = 'normal'

--- a/src/lib/pages/dataset_page.py
+++ b/src/lib/pages/dataset_page.py
@@ -30,7 +30,7 @@ import streamlit as st
 from threading import Thread
 from time import sleep
 import pandas as pd
-# from streamlit.report_thread import add_report_ctx
+from streamlit.script_run_context import add_script_run_ctx
 from streamlit import cli as stcli  # Add CLI so can run Python script directly
 from streamlit import session_state as session_state
 
@@ -396,7 +396,7 @@ def dashboard():
                     log_info("End Sleep in thread")
                     update_success_place.empty()
                 update_success_msg_thread = Thread(target=show_update_success)
-                # add_report_ctx(update_success_msg_thread)
+                add_script_run_ctx(update_success_msg_thread)
                 update_success_msg_thread.start()
                 # show_update_success()
                 log_info("After thread start")

--- a/src/lib/pages/sub_pages/deployment_page/deployment_page.py
+++ b/src/lib/pages/sub_pages/deployment_page/deployment_page.py
@@ -42,7 +42,7 @@ import streamlit as st
 from streamlit import cli as stcli
 from streamlit import session_state
 # this cannot be imported anymore as of Streamlit v1.4.0
-# from streamlit.report_thread import add_report_ctx
+from streamlit.script_run_context import add_script_run_ctx
 import tensorflow as tf
 
 # >>>>>>>>>>>>>>>>>>>>>>TEMP>>>>>>>>>>>>>>>>>>>>>>>>
@@ -279,7 +279,8 @@ def index(RELEASE=True):
 
             # need to add this to avoid Missing ReportContext error
             # https://github.com/streamlit/streamlit/issues/1326
-            # add_report_ctx(client._thread)
+            # NOTE: it's changed from add_report_context() to this since Streamlit v1.4.0
+            add_script_run_ctx(client._thread)
 
             session_state.client_connected = True
 


### PR DESCRIPTION
- by using from streamlit.script_run_context import add_script_run_ctx
- Fix: PrettyMetricPrinter to check 'loss' in metric name.lower()
for inverse color